### PR TITLE
allow datahike-http-server to load backends at run 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dhi.build_artifacts.txt
 trace.edn
 tmp.edn
 .shadow-cljs
+*.temp.*

--- a/deps.edn
+++ b/deps.edn
@@ -59,7 +59,11 @@
                                ring/ring-core                {:mvn/version "1.9.5"}
                                ring/ring-jetty-adapter       {:mvn/version "1.9.5"}
                                metosin/reitit                {:mvn/version "0.5.18"}
-                               ring-cors/ring-cors           {:mvn/version "0.1.13"}}}
+                               ring-cors/ring-cors           {:mvn/version "0.1.13"}
+
+                               ;; test that stores on path can be loaded at runtime for http server e.g. datahike-jdbc.core
+                               io.replikativ/datahike-jdbc {:mvn/version "0.3.50"}
+                               org.xerial/sqlite-jdbc     {:mvn/version "3.41.2.2"}}}
 
            :datomic {:extra-deps {com.datomic/datomic-free {:mvn/version "0.9.5703"}}}
 

--- a/doc/distributed.md
+++ b/doc/distributed.md
@@ -138,6 +138,34 @@ caching and you often run the same queries many times on different queries (e.g.
 to retrieve a daily context in an app against a database only changes with low
 frequency.)
 
+### Adding additional backends to the server
+
+To allow clients who use backends that are not bundled with datahike, the `:stores` property
+list the backends that should be loaded at run time. When embedded you might see some thing like this:
+
+```clojure
+(:require [datahike.api :as d]
+          [datahike-jdbc.core]
+          [datahike-redis.core])
+
+```
+
+To do the equivalent in datahike-http-server we add the `:stores` property to our config.
+This loads custom backends at run time as long as the required jars are on the classpath. 
+
+```clojure
+{:port     4444
+ :level    :debug
+ :dev-mode true
+ :token    "securerandompassword"
+ :stores ["datahike-jdbc.core" "datahike-redis.core"]}
+```
+
+
+
+
+
+
 # JSON support
 
 The remote API supports JSON with embedded [tagged

--- a/http-server/datahike/http/server.clj
+++ b/http-server/datahike/http/server.clj
@@ -206,7 +206,19 @@
                                                   [#"http://localhost" #"http://localhost:8080"])
                  :access-control-allow-methods [:get :put :post :delete])))
 
+(defn load-backends [config]
+  (let [backends (:stores config)] ; e.g. {:stores ["datahike-jdbc.core"]}
+    (doseq [backend backends]
+      (try
+        (require (symbol backend))
+        (println "Loaded backend:" backend)
+        (catch Exception e
+          (log/error "Failed to load backend:" backend ". Is it on the classpath?")
+          (log/error e)
+          (throw e))))))
+
 (defn start-server [config]
+  (load-backends config)
   (run-jetty (app config (default-route-opts muuntaja-with-opts) (atom {})) config))
 
 (defn stop-server [^org.eclipse.jetty.server.Server server]

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -177,3 +177,105 @@
                  "[\"!set\",[[\"Peter\",42]]]")))
         (finally
           (stop-server server))))))
+
+(defn external-backend-server-tests [server-config client-config]
+  (let [{:keys [format]} client-config
+        server (start-server server-config)]
+    (try
+      (let [new-config (api/create-database {:schema-flexibility :read
+                                             :store {:backend :jdbc 
+                                                     :dbname "./external.temp.db" 
+                                                     :dbtype "sqlite"}
+                                             :remote-peer        client-config})
+            _          (is (map? new-config))
+
+            conn                                 (api/connect new-config)
+            {:keys [db-before db-after tx-data]} (api/transact conn [{:name "Peter" :age 42}])
+
+            _ (is (seq tx-data))
+
+            _ (is (not= (:commit-id db-before)
+                        (:commit-id db-after)))
+
+            test-db @conn
+            _       (is (= test-db (api/db conn) db-after))
+
+            query '[:find ?n ?a
+                    :in $
+                    :where
+                    [$ ?e :age ?a]
+                    [$ ?e :name ?n]]
+
+            _ (is (= (api/q query test-db)
+                     #{["Peter" 42]}))
+
+            _ (is (map? (api/query-stats query test-db)))
+
+            _ (is (= (api/pull test-db '[:*] 1)
+                     {:db/id 1, :age 42, :name "Peter"}))
+
+            _ (is (= 3 (count (api/datoms test-db :eavt))))
+
+            _ (is (= 3 (count (api/seek-datoms test-db :eavt))))
+
+            _ (is (map? (api/metrics test-db)))
+
+            _ (is (map? (api/schema test-db)))
+
+            _ (is (map? (api/reverse-schema test-db)))
+
+            _ (is (map? (api/entity test-db 1)))
+
+            _ (when-not (= format :edn)
+                (is (= test-db (api/entity-db (api/entity test-db 1)))))
+
+            _ (is (instance? datahike.remote.RemoteSinceDB (api/since test-db (java.util.Date.))))
+
+            _ (is (instance? datahike.remote.RemoteAsOfDB (api/as-of test-db (java.util.Date.))))
+
+            _ (is (nil? (api/release conn)))
+
+            _ (is (nil? (api/delete-database new-config)))
+
+            _ (is (false? (api/database-exists? new-config)))
+
+            new-config (api/create-database {:schema-flexibility :write
+                                             :store {:backend :jdbc 
+                                                     :dbname "./external.temp.db" 
+                                                     :dbtype "sqlite"}
+                                             :remote-peer        client-config})
+
+            conn (api/connect new-config)
+
+            schema [{:db/ident :name
+                     :db/valueType :db.type/string
+                     :db/cardinality :db.cardinality/one}
+                    {:db/ident :age
+                     :db/valueType :db.type/number
+                     :db/cardinality :db.cardinality/one}]
+
+            _ (api/transact conn schema)
+
+            _ (api/transact conn [{:name "Peter" :age 42}])
+
+            test-db @conn
+            _ (is (= (api/q query test-db)
+                     #{["Peter" 42]}))]
+
+        (is (nil? (api/release conn)))
+        (is (nil? (api/delete-database new-config)))
+        (stop-server server))
+      (finally
+        (stop-server server)))))
+
+(deftest test-external-backend-loaded-at-runtime
+  (testing "Test external backend loaded at runtime."
+    (let [port 23193]
+      (external-backend-server-tests {:port     port
+                                      :join?    false
+                                      :dev-mode false
+                                      :token    "securerandompassword"
+                                      :stores  ["datahike-jdbc.core"]}
+                                      {:backend :datahike-server
+                                      :url     (str "http://localhost:" port)
+                                      :token   "securerandompassword"}))))

--- a/test/datahike/test/http/server_test.clj
+++ b/test/datahike/test/http/server_test.clj
@@ -183,8 +183,8 @@
         server (start-server server-config)]
     (try
       (let [new-config (api/create-database {:schema-flexibility :read
-                                             :store {:backend :jdbc 
-                                                     :dbname "./external.temp.db" 
+                                             :store {:backend :jdbc
+                                                     :dbname "./external.temp.db"
                                                      :dbtype "sqlite"}
                                              :remote-peer        client-config})
             _          (is (map? new-config))
@@ -240,8 +240,8 @@
             _ (is (false? (api/database-exists? new-config)))
 
             new-config (api/create-database {:schema-flexibility :write
-                                             :store {:backend :jdbc 
-                                                     :dbname "./external.temp.db" 
+                                             :store {:backend :jdbc
+                                                     :dbname "./external.temp.db"
                                                      :dbtype "sqlite"}
                                              :remote-peer        client-config})
 
@@ -276,6 +276,6 @@
                                       :dev-mode false
                                       :token    "securerandompassword"
                                       :stores  ["datahike-jdbc.core"]}
-                                      {:backend :datahike-server
+                                     {:backend :datahike-server
                                       :url     (str "http://localhost:" port)
                                       :token   "securerandompassword"}))))


### PR DESCRIPTION
#### SUMMARY
The datahike-http-server only supports memory and file backend so if a remote client expects a different backend the operations will fail. It also means to use other backends the user would have to create their own datahike-http-server

##### Feature
- [ ] Implements an existing feature request. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [x] Integration tests added
- [x] Documentation added
- [ ] Architecture Decision Record added 
- [x] Formatting checked
